### PR TITLE
Remove deprecated `bottle :unneeded`

### DIFF
--- a/Formula/bifrost.rb
+++ b/Formula/bifrost.rb
@@ -6,7 +6,6 @@ class Bifrost < Formula
   desc "The CLI tools for Fortress"
   homepage "https://d.foundation"
   version "0.13.2"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
The `unneeded` designation is no longer valid.

#### What's this PR do?

Allows the tap to be used again.

#### What are the relevant Git tickets?

Fixes #2 

#### Any background context you want to provide? (if appropriate)

- Deprecation: https://github.com/Homebrew/homebrew-core/issues/75943
- I am aware that this file is autogenerated, so maybe you all can update the version of GoReleaser used, assuming it is fixed in there, and redo this. This manual change should only be needed in the short term.
- There are also some other cleanup simplifications that could be done manually, see my [fork](https://github.com/qayshp/homebrew-tap-dwarvesf/blob/256deafbcdaef22cbf71c272d398c1b7c867428f/Formula/bifrost.rb), but they are not necessary.